### PR TITLE
alpine: Try to workaround TLS error by not using https:// for mirror

### DIFF
--- a/include/alpine.sh
+++ b/include/alpine.sh
@@ -2,7 +2,8 @@ readonly RELVER=${RELVER:=3.5}
 readonly ARCH=${ARCH:=x86_64}
 
 readonly DISTNAME='alpine'
-readonly BASEURL="https://cz.alpinelinux.org/alpine/v$RELVER"
+# Don't use https:// for this script, it doesn't work for an unknown reason.
+readonly BASEURL="http://cz.alpinelinux.org/alpine/v$RELVER"
 
 readonly APK="$INSTALL/apk.static"
 readonly APK_KEYS_DIR="$INSTALL/keys"


### PR DESCRIPTION
    +++ /var/build/install.fZb/apk.static --arch=x86_64 --root=. --keys-dir=/var/build/install.fZb/keys --update-cache --initdb add alpine-base
    fetch https://cz.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
    139810308753244:error:14007086:SSL routines:CONNECT_CR_CERT:certificate verify failed:ssl_clnt.c:1026:

APKINDEXes and packages are digitally signed and apk verifies these signatures, so https:// for aports mirror actually does not add much security. Moreover, cz.alpinelinux.org is hosted on vpsFree.

Fixes #31 (hopefully)

/cc @aither64